### PR TITLE
Feat!: Remove automatic element to string equality check

### DIFF
--- a/hyperscript/element.py
+++ b/hyperscript/element.py
@@ -131,6 +131,4 @@ class Element:
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Element):
             return str(self) == str(other)
-        if isinstance(other, str):
-            return str(self) == other
-        return False
+        return super().__eq__(other)

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -84,8 +84,6 @@ class TestElement(unittest.TestCase):
 
         self.assertEqual(h("div", h("p", "Foo")), h("div", h("p", "Foo")))
 
-        self.assertEqual(h("div", h("p", "Foo")), "<div><p>Foo</p></div>")
-
         self.assertNotEqual(h("div"), h("p"))
 
         self.assertNotEqual(h("div", h("p", "Foo")), h("div", h("p", "Bar")))


### PR DESCRIPTION
This check, while maybe situationally convenient, seems unnecessary and is causing extra calls to _parts() when parsing children, which could be expensive.